### PR TITLE
Bomberman 64 Weight fix

### DIFF
--- a/worlds/keymasters_keep/games/bomberman_64_game.py
+++ b/worlds/keymasters_keep/games/bomberman_64_game.py
@@ -80,7 +80,7 @@ class Bomberman64Game(Game):
                 data={"STAGE": (self.deep_stages, 1)},
                 is_time_consuming=True,
                 is_difficult=False,
-                weight=23,
+                weight=2,
             ),
             GameObjectiveTemplate(
                 label="Complete all stages in WORLD",
@@ -201,6 +201,6 @@ class Bomberman64Game(Game):
 # Archipelago Options
 class Bomberman64AllowRainbowPalace(Toggle):
     """
-    Whether objectives are allowed require accessing the secret Rainbow Palace stages.
+    Whether objectives are allowed to require accessing the secret Rainbow Palace stages.
     """
     display_name = "Bomberman 64 Allow Rainbow Palace"


### PR DESCRIPTION
Resolves an issue with the weighting of one objective being far too high. Also fixes grammar of the Archipelago option description.
