### PR TITLE
Client: Clicking game name and "X trials" message navigates to "Available Trials" tab

### DIFF
--- a/worlds/keymasters_keep/client_gui/client_gui.py
+++ b/worlds/keymasters_keep/client_gui/client_gui.py
@@ -26,7 +26,7 @@ class KeymastersKeepManager(GameManager):
         self.add_client_tab("Keymaster's Keep", self.keymasters_keep_tab_layout)
 
         self.trials_tab_layout = TrialsTabLayout(self.ctx)
-        self.add_client_tab("Available Trials", self.trials_tab_layout)
+        self.available_trials_tab = self.add_client_tab("Available Trials", self.trials_tab_layout)
 
         self.trials_completed_tab_layout = TrialsCompletedTabLayout(self.ctx)
         self.add_client_tab("Completed Trials", self.trials_completed_tab_layout)

--- a/worlds/keymasters_keep/client_gui/client_gui_layouts.py
+++ b/worlds/keymasters_keep/client_gui/client_gui_layouts.py
@@ -56,7 +56,7 @@ class KeepAreaLayout(BoxLayout):
 
     area: KeymastersKeepRegions
     unlock_button: Button
-    locked_by_label: Label
+    locked_by_button: Label
 
     def __init__(
         self,
@@ -99,7 +99,7 @@ class KeepAreaLayout(BoxLayout):
 
         self.add_widget(area_label)
 
-        self.locked_by_label: Label = Label(
+        self.locked_by_button: Button = Button(
             text="",
             markup=True,
             size_hint_x=0.77,
@@ -107,23 +107,25 @@ class KeepAreaLayout(BoxLayout):
             height="40dp",
             halign="left",
             valign="middle",
+            background_normal="",
+            background_color=(0, 0, 0, 0)
         )
 
         if bool(locked_by):
-            self.locked_by_label.text = "[b]Needs:[/b]  " + "    ".join(
+            self.locked_by_button.text = "[b]Needs:[/b]  " + "    ".join(
                 [key_to_markup_text(key) for key in locked_by]
             )
 
-        self.locked_by_label.bind(size=lambda label, size: setattr(label, "text_size", size))
+        self.locked_by_button.bind(size=lambda btn, size: setattr(btn, "text_size", size))
 
-        self.add_widget(self.locked_by_label)
+        self.add_widget(self.locked_by_button)
 
     def update(self, locked_by: Optional[List[KeymastersKeepItems]], unlocked: bool) -> None:
         if locked_by:
             self.unlock_button.disabled = True
             self.unlock_button.text = "Locked"
 
-            self.locked_by_label.text = "[b]Needs:[/b]  " + "    ".join(
+            self.locked_by_button.text = "[b]Needs:[/b]  " + "    ".join(
                 [key_to_markup_text(key) for key in locked_by]
             )
         elif unlocked:
@@ -133,12 +135,14 @@ class KeepAreaLayout(BoxLayout):
             game: str = self.ctx.area_games[self.area.value]
             trial_count: int = len(self.ctx.area_trials[self.area])
 
-            self.locked_by_label.text = f"[b]Game:[/b]  {game}    [color=888888]{trial_count} trials[/color]"
+            self.locked_by_button.text = f"[b]Game:[/b]  {game}    [color=4e7aa6]{trial_count} trials[/color]"
+            self.locked_by_button.color = [111/255, 174/255, 237/255, 1] # same color as #6faeed
+            self.locked_by_button.bind(on_press=lambda _: self.ctx.ui.tabs.switch_to(self.ctx.ui.available_trials_tab)) 
         else:
             self.unlock_button.disabled = False
             self.unlock_button.text = "Unlock"
 
-            self.locked_by_label.text = ""
+            self.locked_by_button.text = ""
 
     def on_unlock_button_press(self, _) -> None:
         self.unlock_button.disabled = True

--- a/worlds/keymasters_keep/client_gui/client_gui_layouts.py
+++ b/worlds/keymasters_keep/client_gui/client_gui_layouts.py
@@ -56,7 +56,7 @@ class KeepAreaLayout(BoxLayout):
 
     area: KeymastersKeepRegions
     unlock_button: Button
-    locked_by_button: Label
+    locked_by_button: Button
 
     def __init__(
         self,
@@ -135,8 +135,7 @@ class KeepAreaLayout(BoxLayout):
             game: str = self.ctx.area_games[self.area.value]
             trial_count: int = len(self.ctx.area_trials[self.area])
 
-            self.locked_by_button.text = f"[b]Game:[/b]  {game}    [color=4e7aa6]{trial_count} trials[/color]"
-            self.locked_by_button.color = [111/255, 174/255, 237/255, 1] # same color as #6faeed
+            self.locked_by_button.text = f"[b]Game:[/b]  {game}    [color=6faeed][u]{trial_count} trials[/u][/color]"
             self.locked_by_button.bind(on_press=lambda _: self.ctx.ui.tabs.switch_to(self.ctx.ui.available_trials_tab)) 
         else:
             self.unlock_button.disabled = False


### PR DESCRIPTION
## What is this fixing or adding?
When I was initially checking out KK, it wasn't clear to me that the checks were in a separate tab. My first instinct was to click the "X trials" text by the game name, which didn't do anything. 

So this PR makes it clickable. When it's clicked, it switches to the "Available Trials" tab.

## How was this tested?
Generated a single game (SF6) KK locally and connected via the KK client, then clicked multiple keep areas and unlocks to ensure that all 3 states for keep areas functioned without error.

## If this makes graphical changes, please attach screenshots.
(The only graphical change was the "Game: Street Fighter 6    X trials" text color, to hopefully better convey that it's now clickable. No preference on colors for this, so feel free to suggest/change after.)

![kk-clickable-trials-message](https://github.com/user-attachments/assets/b7a99622-e548-45b5-920f-23afdfd0170f)
