### PR TITLE
Add Guitar Hero II, World Tour, 5, and Warriors of Rock

### DIFF
--- a/worlds/keymasters_keep/games/guitar_hero_5_game.py
+++ b/worlds/keymasters_keep/games/guitar_hero_5_game.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+class GuitarHero5Game(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Guitar Hero 5"
+    platform = KeymastersKeepGamePlatforms.X360
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS3,
+        KeymastersKeepGamePlatforms.PS2,
+        KeymastersKeepGamePlatforms.WII,
+    ]
+
+    is_adult_only_or_unrated = False
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "2 Minutes to Midnight",
+            "20th Century Boy",
+            "21st Century Schizoid Man",
+            "A-Punk",
+            "All Along the Watchtower",
+            "All The Pretty Faces",
+            "American Girl",
+            "Back Round",
+            "Bleed American",
+            "Blue Day",
+            "Blue Orchid",
+            "Brianstorm",
+            "Bring the Noise 20XX",
+            "Bullet with Butterfly Wings",
+            "Cigarettes, Wedding Bands",
+            "Comedown",
+            "Dancing with Myself",
+            "Deadbolt",
+            "Demon(s)",
+            "Disconnected",
+            "Done with Everything, Die for Nothing",
+            "Do You Feel Like We Do?",
+            "Du Hast",
+            "Ex-Girlfriend",
+            "Fame",
+            "Feel Good Inc.",
+            "Gamma Ray",
+            "Gratitude",
+            "Hungry Like the Wolf",
+            "Hurts So Good",
+            "Incinerate",
+            "In My Place",
+            "In the Meantime",
+            "Jailbreak",
+            "Judith",
+            "Kryptonite",
+            "L.A.",
+            "Lithium",
+            "Lonely Is the Night",
+            "Looks That Kill",
+            "Lust for Life",
+            "Maiden, Mother & Crone",
+            "Make It with Chu",
+            "Medicate",
+            "Mirror People",
+            "Nearly Lost You",
+            "Never Miss a Beat",
+            "No One to Depend On",
+            "One Big Holiday",
+            "Only Happy When It Rains",
+            "Play That Funky Music",
+            "Plug In Baby",
+            "Ring of Fire",
+            "The Rock Show",
+            "Runnin' Down a Dream",
+            "Saturday Night's Alright for Fighting",
+            "Scatterbrain",
+            "Send a Little Love Token",
+            "Seven",
+            "Sex on Fire",
+            "Shout It Out Loud",
+            "Six Days a Week",
+            "Smells Like Teen Spirit",
+            "Sneak Out",
+            "So Lonely",
+            "Song 2",
+            "Sowing Season (Yeah)",
+            "The Spirit of Radio",
+            "Steady, As She Goes",
+            "Streamline Woman",
+            "Sultans of Swing",
+            "Superstition",
+            "Sweating Bullets",
+            "Sympathy for the Devil",
+            "They Say",
+            "Under Pressure",
+            "Wannabe in L.A.",
+            "We're an American Band",
+            "What I Got",
+            "Why Bother?",
+            "Wolf Like Me",
+            "Woman From Tokyo",
+            "You and Me",
+            "You Give Love a Bad Name",
+            "Younk Funk"
+        ]

--- a/worlds/keymasters_keep/games/guitar_hero_ii_game.py
+++ b/worlds/keymasters_keep/games/guitar_hero_ii_game.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from Options import Toggle
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class GuitarHeroIIArchipelagoOptions:
+    guitar_hero_ii_bonus_tracks: GuitarHeroIIBonusTracks
+    guitar_hero_ii_x360_tracks: GuitarHeroIIX360Tracks
+
+
+class GuitarHeroIIGame(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Guitar Hero II"
+    platform = KeymastersKeepGamePlatforms.PS2
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.X360
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = GuitarHeroIIArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        track_list = self.tracks_base
+        if self.archipelago_options.guitar_hero_ii_bonus_tracks.value:
+            track_list += self.tracks_bonus
+        if self.archipelago_options.guitar_hero_ii_x360_tracks.value:
+            track_list += self.tracks_x360
+        if self.archipelago_options.guitar_hero_ii_bonus_tracks.value and self.archipelago_options.guitar_hero_ii_x360_tracks.value:
+            track_list += self.tracks_x360_bonus
+        return sorted(track_list)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        # Some songs moved tiers between PS2 and X360, did my best to write these cleanly
+        return [
+            "Shout at the Devil (tier 1)",
+            "Mother (tier 1/2)",
+            "Surrender (tier 1)",
+            "Woman (tier 1/2)",
+            "Tonight I'm Gonna Rock You Tonight (tier 1/2)",
+            "Strutter (tier 2/1)",
+            "Heart-Shaped Box (tier 2/1)",
+            "Message in a Bottle (tier 2/3)",
+            "You Really Got Me (tier 2)",
+            "Carry On Wayward Son (tier 2/3)",
+            "Monkey Wrench (tier 3/4)",
+            "Them Bones (tier 3)",
+            "Search and Destroy (tier 3)",
+            "Tattooed Love Boys (tier 3/5)",
+            "War Pigs (tier 3)",
+            "Cherry Pie (tier 4/2)",
+            "Who Was in My Room Last Night? (tier 4)",
+            "Girlfriend (tier 4)",
+            "Can't You Hear Me Knockin' (tier 4)",
+            "Sweet Child o' Mine (tier 4)",
+            "Killing in the Name (tier 5/6)",
+            "John the Fisherman (tier 5)",
+            "Freya (tier 5/6)",
+            "Bad Reputation (tier 5)",
+            "Last Child (tier 5)",
+            "Crazy on You (tier 6)",
+            "Trippin' on a Hole in a Paper Heart (tier 6)",
+            "Rock This Town (tier 6/7)",
+            "Jessica (tier 6/5)",
+            "Stop (tier 6)",
+            "Madhouse (tier 7)",
+            "Carry Me Home (tier 7/8)",
+            "Laid to Rest (tier 7)",
+            "Psychobilly Freakout (tier 7)",
+            "YYZ (tier 7)",
+            "Beast and the Harlot (tier 8)",
+            "Institutionalized (tier 8)",
+            "Misirlou (tier 8)",
+            "Hangar 18 (tier 8)",
+            "Free Bird (tier 8)",
+        ]
+    
+    @functools.cached_property
+    def tracks_bonus(self) -> List[str]:
+        return [
+            "Arterial Black (bonus)",
+            "Collide (bonus)",
+            "Elephant Bones (bonus)",
+            "Fall of Pangea (bonus)",
+            "FTK (bonus)",
+            "Gemini (bonus)",
+            "Jordan (bonus)",
+            "Laughtrack (bonus)",
+            "Less Talk More Rokk (bonus)",
+            "Mr. Fix It (bonus)",
+            "One for the Road (bonus)",
+            "Parasite (bonus)",
+            "Push Push (Lady Lightning) (bonus)",
+            "Radium Eyes (bonus)",
+            "Raw Dog (bonus)",
+            "Red Lottery (bonus)",
+            "Six (bonus)",
+            "Soy Bomb (bonus)",
+            "The Light That Blinds (bonus)",
+            "The New Black (bonus)",
+            "Thunderhorse (bonus)",
+            "Trogdor (bonus)",
+            "X-Stream (bonus)",
+            "Yes We Can (bonus)"
+        ]
+    
+    @functools.cached_property
+    def tracks_x360(self) -> List[str]:
+        return [
+            "Possum Kingdom (tier 1)",
+            "Salvation (tier 1)",
+            "Life Wasted (tier 2)",
+            "Billion Dollar Babies (tier 3)",
+            "Hush (tier 4)",
+            "Rock and Roll, Hoochie Koo (tier 5)",
+            "Dead! (tier 6)",
+            "The Trooper (tier 7)"
+        ]
+    
+    @functools.cached_property
+    def tracks_x360_bonus(self) -> List[str]:
+        return [
+            "Drink Up (bonus)",
+            "Kicked to the Curb (bonus)"
+        ]
+
+
+# Archipelago Options
+class GuitarHeroIIBonusTracks(Toggle):
+    """
+    Indicates whether to include the bonus tracks in the list for Guitar Hero II.
+    """
+
+    display_name = "Guitar Hero II Bonus Tracks"
+    default = False
+
+class GuitarHeroIIX360Tracks(Toggle):
+    """
+    Indicates whether to include the XBox 360 exclusive tracks in the list for Guitar Hero II.
+    """
+
+    display_name = "Guitar Hero II X360 Tracks"
+    default = False

--- a/worlds/keymasters_keep/games/guitar_hero_warriors_of_rock_game.py
+++ b/worlds/keymasters_keep/games/guitar_hero_warriors_of_rock_game.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+class GuitarHeroWarriorsOfRockGame(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Guitar Hero: Warriors of Rock"
+    platform = KeymastersKeepGamePlatforms.X360
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS3,
+        KeymastersKeepGamePlatforms.WII,
+    ]
+
+    is_adult_only_or_unrated = False
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "Again",
+            "Aqualung",
+            "Bat Country",
+            "Been Caught Stealing",
+            "Black Rain",
+            "Black Widow of La Porte",
+            "Bleed It Out",
+            "Bloodlines",
+            "Bodies",
+            "Bohemian Rhapsody",
+            "Burn",
+            "Burnin' for You",
+            "Call Me the Breeze",
+            "Calling",
+            "Chemical Warfare",
+            "Cherry Bomb",
+            "Children of the Grave",
+            "Cryin'",
+            "Dance, Dance",
+            "Dancing Through Sunday",
+            "Deadfall",
+            "Fascination Street",
+            "The Feel Good Drag",
+            "Feels Like the First Time",
+            "Fortunate Son",
+            "Free Ride",
+            "Fury of the Storm",
+            "Get Free",
+            "Ghost",
+            "Graduate",
+            "Hard to See",
+            "Holy Wars... The Punishment Due",
+            "How You Remind Me",
+            "I Know What I Am",
+            "I'm Broken",
+            "I'm Not Okay (I Promise)",
+            "If You Want Peace... Prepare for War",
+            "Indians",
+            "Interstate Love Song",
+            "It's Only Another Parsec...",
+            "Jet City Woman",
+            "Lasso",
+            "Listen to Her Heart",
+            "Losing My Religion",
+            "Love Gun",
+            "Lunatic Fringe",
+            "Machinehead",
+            "Modern Day Cowboy",
+            "Money for Nothing",
+            "Motivation",
+            "Move It On Over",
+            "Nemesis",
+            "No More Mr. Nice Guy",
+            "No Way Back",
+            "The Outsider",
+            "Paranoid",
+            "Pour Some Sugar on Me",
+            "Psychosocial",
+            "Ravenous",
+            "Re-Ignition",
+            "Renegade",
+            "(You Can Still) Rock in America",
+            "Rockin' in the Free World",
+            "Savior",
+            "Scumbag Blues",
+            "Self Esteem",
+            "Setting Fire to Sleeping Giants",
+            "Seven Nation Army",
+            "Sharp Dressed Man",
+            "Slow Hands",
+            "Speeding (Vault Version)",
+            "Stray Cat Blues",
+            "Sudden Death",
+            "Suffocated",
+            "Theme from Spiderman",
+            "There's No Secrets This Year",
+            "This Day We Fight!",
+            "Tick Tick Boom",
+            "Ties That Bind",
+            "Tones of Home",
+            "2112 Pt. 1 -- Overture",
+            "2112 Pt. 2 -- The Temples of Syrinx",
+            "2112 Pt. 3 -- Discovery",
+            "2112 Pt. 4 -- Presentation",
+            "2112 Pt. 5 -- Oracle: The Dream",
+            "2112 Pt. 6 -- Soliloquy",
+            "2112 Pt. 7 -- Grand Finale",
+            "Unskinny Bop",
+            "Uprising",
+            "Waidmanns Heil",
+            "We're Not Gonna Take It",
+            "What Do I Get?",
+            "Wish"
+        ]

--- a/worlds/keymasters_keep/games/guitar_hero_world_tour_game.py
+++ b/worlds/keymasters_keep/games/guitar_hero_world_tour_game.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+class GuitarHeroWorldTourGame(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Guitar Hero World Tour"
+    platform = KeymastersKeepGamePlatforms.X360
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS3,
+        KeymastersKeepGamePlatforms.PS2,
+        KeymastersKeepGamePlatforms.PC,
+        KeymastersKeepGamePlatforms.NGAGE,
+        KeymastersKeepGamePlatforms.WII,
+    ]
+
+    is_adult_only_or_unrated = False
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "About a Girl",
+            "Aggro",
+            "American Woman",
+            "Antisocial",
+            "Are You Gonna Go My Way",
+            "Assassin",
+            "B.Y.O.B.",
+            "Band on the Run",
+            "Beat it",
+            "Beautiful Disaster",
+            "Crazy Train",
+            "Dammit",
+            "Demolition Man",
+            "Do It Again",
+            "Escuela de Calor",
+            "Everlong",
+            "Eye of the Tiger",
+            "Feel the Pain",
+            "Float On",
+            "Freak on a Leash",
+            "Go Your Own Way",
+            "Good God",
+            "Hail to the Freaks",
+            "Heartbreaker",
+            "Hey Man, Nice Shot",
+            "Hollywood Nights",
+            "Hot for Teacher",
+            "Hotel California",
+            "The Joker",
+            "Kick Out the Jams",
+            "The Kill",
+            "L'Via L'Viaquez",
+            "La Bamba",
+            "Lazy Eye",
+            "Livin' on a Prayer",
+            "Love Me Two Times",
+            "Love Removal Machine",
+            "Love Spreads",
+            "The Middle",
+            "Misery Business",
+            "Monsoon",
+            "Mountain Song",
+            "Mr. Crowley",
+            "Never Too Late",
+            "No Sleep Till Brooklyn",
+            "Nuvole E Lenzuola",
+            "Obstacle 1",
+            "On the Road Again",
+            "One Armed Scissor",
+            "The One I Love",
+            "One Way or Another",
+            "Our Truth",
+            "Overkill",
+            "Parabola",
+            "Pretty Vacant",
+            "Prisoner of Society",
+            "Pull Me Under",
+            "Purple Haze",
+            "Ramblin' Man",
+            "Re-Education (Through Labor)",
+            "Rebel Yell",
+            "Rooftops (A Liberation Broadcast)",
+            "Santeria",
+            "Satch Boogie",
+            "Schism",
+            "Scream Aim Fire",
+            "Shiver",
+            "Some Might Say",
+            "Soul Doubt",
+            "Spiderwebs",
+            "Stillborn",
+            "Stranglehold",
+            "Sweet Home Alabama",
+            "Today",
+            "Too Much, Too Young, Too Fast",
+            "Toy Boy",
+            "Trapped Under Ice",
+            "Up Around the Bend",
+            "Vicarious",
+            "VinterNoll2",
+            "Weapon of Choice",
+            "What I've Done",
+            "The Wind Cries Mary",
+            "You're Gonna Say Yeah!"
+        ]


### PR DESCRIPTION
You knew these were coming. GH2 has toggles for bonus tracks and X360 exclusives, the other ones have straight setlists so no options needed there.