### PR TITLE
Keymasters Keep, update to Advance Wars Days of Ruin

### DIFF
--- a/worlds/keymasters_keep/games/advance_wars_days_of_ruin_game.py
+++ b/worlds/keymasters_keep/games/advance_wars_days_of_ruin_game.py
@@ -58,6 +58,12 @@ class AdvanceWarsDaysOfRuinGame(Game):
                     "TERRAIN": (self.freeplay_terrain, 1),
                 },
             ),
+            GameObjectiveTemplate(
+                label="Promote 5x UNIT to V Rank and have them survive, Commander unit does not count",
+                data={
+                    "UNIT": (self.units_combat, 1),
+                },
+            ),
         ]
 
     def game_objective_templates(self) -> List[GameObjectiveTemplate]:
@@ -361,8 +367,6 @@ class AdvanceWarsDaysOfRuinGame(Game):
         return sorted(
             self.maps_classic
             + self.maps_2p
-            + self.maps_3p
-            + self.maps_4p
             + self.maps_trials_2p
         )
 
@@ -404,6 +408,33 @@ class AdvanceWarsDaysOfRuinGame(Game):
         ]
 
     @staticmethod
+    def units_combat() -> List[str]:
+        return [
+            "Infantry",
+            "Mech",
+            "Bike",
+            "Recon",
+            "Anti-Air",
+            "Tank",
+            "Medium Tank",
+            "War Tank",
+            "Artillery",
+            "Anti-Tank",
+            "Rockets",
+            "Missiles",
+            "Fighter",
+            "Bomber",
+            "Duster",
+            "B Copter",
+            "Seaplane",
+            "Battleship",
+            "Carrier",
+            "Submarine",
+            "Cruiser",
+            "Gunboat",
+        ]
+
+    @staticmethod
     def units_airfield() -> List[str]:
         return [
             "Fighter",
@@ -436,7 +467,6 @@ class AdvanceWarsDaysOfRuinGame(Game):
     def units_port() -> List[str]:
         return [
             "Battleship",
-            "Carrier",
             "Submarine",
             "Cruiser",
             "Lander",


### PR DESCRIPTION
## What is this fixing or adding?
- Add optional objective to rank up a random combat capable unit
- Correct freeplay 2p maps to not include 3p and 4p maps as there is no way to play these maps with less than the amount of players they are made for

## How was this tested?
Tested by generating KeyMaster Keep a few times to see how the challenges look like

## If this makes graphical changes, please attach screenshots.
