### PR TITLE
Keymasters Keep, update to Mages of Mystralia

### DIFF
--- a/worlds/keymasters_keep/games/mages_of_mystralia_game.py
+++ b/worlds/keymasters_keep/games/mages_of_mystralia_game.py
@@ -76,7 +76,7 @@ class MagesOfMystraliaGame(Game):
                 data={
                     "ELIXER": (self.elixirs, 1),
                 },
-                is_time_consuming=False,
+                is_time_consuming=True,
                 is_difficult=False,
                 weight=2,
             ),
@@ -87,7 +87,7 @@ class MagesOfMystraliaGame(Game):
                     "BEHAVIORS": (self.behaviors, 4),
                 },
                 is_time_consuming=True,
-                is_difficult=False,
+                is_difficult=True,
                 weight=1,
             ),
             GameObjectiveTemplate(
@@ -97,10 +97,22 @@ class MagesOfMystraliaGame(Game):
                     "BEHAVIORS": (self.behaviors, 4),
                 },
                 is_time_consuming=True,
-                is_difficult=False,
+                is_difficult=True,
+                weight=1,
+            ),
+            GameObjectiveTemplate(
+                label="Play the Adventure and get the following  Behaviors: BEHAVIORS  Augment: AUGMENTS  Trigger: TRIGGER",
+                data={
+                    "BEHAVIORS": (self.behaviors, 2),
+                    "AUGMENTS": (self.augments, 1),
+                    "TRIGGER": (self.triggers, 1),
+                },
+                is_time_consuming=True,
+                is_difficult=True,
                 weight=1,
             ),
         ]
+
 
     @staticmethod
     def difficulties() -> List[str]:


### PR DESCRIPTION
## What is this fixing or adding?
- Add extra challenge to go and find a number of spell runes. This may involve multiple boss fights or reaching near end game state
- Adjusted difficulty or time_consuming flags for challenges involving the adventure, generally they will take significantly longer than whatever hall of trials throws at us or for some involve multiple boss fights

## How was this tested?
Generated several Key Master Keep games and see how challenges / optionals look like

## If this makes graphical changes, please attach screenshots.
