### PR TITLE
Add 5 Rock Band games

### DIFF
--- a/worlds/keymasters_keep/games/lego_rock_band_game.py
+++ b/worlds/keymasters_keep/games/lego_rock_band_game.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from Options import Toggle
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class LegoRockBandArchipelagoOptions:
+    lego_rock_band_nds_only: LegoRockBandNDSOnly
+
+
+class LegoRockBandGame(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Lego Rock Band"
+    platform = KeymastersKeepGamePlatforms.PS3
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.X360,
+        KeymastersKeepGamePlatforms.WII,
+        KeymastersKeepGamePlatforms.NDS
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = LegoRockBandArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3,
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1,
+            ),
+        ]
+
+    def tracks(self) -> List[str]:
+        track_list = self.tracks_nds
+
+        if not self.archipelago_options.lego_rock_band_nds_only.value:
+            track_list += self.tracks_base
+
+        return sorted(track_list)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "Aliens Exist",
+            "Breakout",
+            "Crocodile Rock",
+            "Dig",
+            "Dreaming of You",
+            "Every Little Thing She Does Is Magic",
+            "Fire",
+            "Make Me Smile (Come Up and See Me)",
+            "Naïve",
+            "Real Wild Child",
+            "Ride a White Swan",
+            "Rooftops (A Liberation Broadcast)",
+            "Short and Sweet",
+            "Stumble and Fall",
+            "Summer of '69",
+            "Thunder",
+            "Tick Tick Boom",
+            "Valerie",
+            "Word Up!",
+            "You Give Love a Bad Name"
+        ]
+
+    @functools.cached_property
+    def tracks_nds(self) -> List[str]:
+        return [
+            "A-Punk",
+            "Accidentally in Love",
+            "Check Yes Juliet",
+            "Crash",
+            "Free Fallin'",
+            "Ghostbusters",
+            "Girls & Boys",
+            "Grace",
+            "I Want You Back",
+            "In Too Deep",
+            "Kung Fu Fighting",
+            "Let's Dance",
+            "Life Is a Highway",
+            "Monster",
+            "Ruby",
+            "So What",
+            "Song 2",
+            "Suddenly I See",
+            "Swing, Swing",
+            "The Final Countdown",
+            "The Passenger",
+            "Two Princes",
+            "Walking on Sunshine",
+            "We Are the Champions",
+            "We Will Rock You"
+        ]
+
+
+# Archipelago Options
+class LegoRockBandNDSOnly(Toggle):
+    """
+    Indicates whether to only include the Nintendo DS tracks in the list for Lego Rock Band.
+    """
+
+    display_name = "Lego Rock Band NDS Only"

--- a/worlds/keymasters_keep/games/rock_band_2_game.py
+++ b/worlds/keymasters_keep/games/rock_band_2_game.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class RockBand2ArchipelagoOptions:
+    pass
+
+
+class RockBand2Game(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Rock Band 2"
+    platform = KeymastersKeepGamePlatforms.X360
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS3,
+        KeymastersKeepGamePlatforms.PS2,
+        KeymastersKeepGamePlatforms.WII,
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = RockBand2ArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "A Jagged Gorgeous Winter",
+            "Ace of Spades '08",
+            "Alabama Getaway",
+            "Alex Chilton",
+            "Alive",
+            "Almost Easy",
+            "American Woman",
+            "Any Way You Want It",
+            "Aqualung",
+            "Bad Reputation",
+            "Battery",
+            "Bodhisattva",
+            "Carry On Wayward Son",
+            "Chop Suey",
+            "Colony of Birchmen",
+            "Come Out and Play (Keep 'Em Separated)",
+            "Conventional Lover",
+            "Cool for Cats",
+            "De-Luxe",
+            "Down with the Sickness",
+            "Drain You",
+            "E-Pro",
+            "Everlong",
+            "Eye of the Tiger",
+            "Feel the Pain",
+            "Float On",
+            "Get Clean",
+            "Girl's Not Grey",
+            "Give It All",
+            "Give It Away",
+            "Go Your Own Way",
+            "Hello There",
+            "Hungry Like the Wolf",
+            "I Was Wrong",
+            "Kids in America",
+            "Lazy Eye",
+            "Let There Be Rock",
+            "Livin' on a Prayer",
+            "Lump",
+            "Man in the Box",
+            "Master Exploder",
+            "Mountain Song",
+            "My Own Worst Enemy",
+            "New Kid in School",
+            "Night Lies",
+            "Nine in the Afternoon",
+            "One Step Closer",
+            "One Way or Another",
+            "Our Truth",
+            "Painkiller",
+            "Panic Attack",
+            "PDA",
+            "Peace Sells",
+            "Pinball Wizard",
+            "Pretend We're Dead",
+            "Psycho Killer",
+            "Pump It Up",
+            "Ramblin' Man",
+            "Rebel Girl",
+            "Rob the Prez-O-Dent",
+            "Rock'n Me",
+            "Round and Round",
+            "Shackler's Revenge",
+            "Shooting Star",
+            "Shoulder to the Plow",
+            "So What'cha Want",
+            "Souls of Black",
+            "Spirit in the Sky",
+            "Spoonman",
+            "Supreme Girl",
+            "Tangled Up in Blue",
+            "Teen Age Riot",
+            "Testify",
+            "That's What You Get",
+            "The Middle",
+            "The Trees (Vault Edition)",
+            "Today",
+            "Uncontrollable Urge",
+            "Visions",
+            "We Got the Beat",
+            "Welcome to the Neighborhood",
+            "Where'd You Go?",
+            "White Wedding (Part 1)",
+            "You Oughta Know"
+        ]
+
+
+# Archipelago Options
+# ...

--- a/worlds/keymasters_keep/games/rock_band_3_game.py
+++ b/worlds/keymasters_keep/games/rock_band_3_game.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from Options import Toggle
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class RockBand3ArchipelagoOptions:
+    rock_band_3_nds_only: RockBand3NDSOnly
+
+
+class RockBand3Game(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Rock Band 3"
+    platform = KeymastersKeepGamePlatforms.PS3
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.X360,
+        KeymastersKeepGamePlatforms.WII,
+        KeymastersKeepGamePlatforms.NDS
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = RockBand3ArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3,
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1,
+            ),
+        ]
+
+    def tracks(self) -> List[str]:
+        track_list = self.tracks_nds
+
+        if not self.archipelago_options.rock_band_3_nds_only.value:
+            track_list += self.tracks_base
+
+        return sorted(track_list)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "20th Century Boy",
+            "25 or 6 to 4",
+            "Antibodies",
+            "Beast and the Harlot",
+            "The Beautiful People",
+            "Before I Forget",
+            "Caught in a Mosh",
+            "Centerfold",
+            "The Con",
+            "Dead End Friends",
+            "Don't Bury Me... I'm Still Not Dead",
+            "Don't Stand So Close to Me",
+            "Du Hast",
+            "Everybody Wants to Rule the World",
+            "False Alarm",
+            "Fly Like an Eagle",
+            "Foolin'",
+            "Free Bird",
+            "Get Up, Stand Up",
+            "Good Vibrations (Live)",
+            "Heart of Glass",
+            "Hey Man, Nice Shot",
+            "I Can See for Miles",
+            "I Got You (I Feel Good) (Alternative Version)",
+            "I Need to Know",
+            "I Wanna Be Sedated",
+            "Imagine",
+            "In a Big Country",
+            "In the Meantime",
+            "Jerry Was a Race Car Driver",
+            "Killing Loneliness",
+            "The Killing Moon",
+            "King George",
+            "Last Dance",
+            "Living in America",
+            "Llama",
+            "Low Rider",
+            "Me Enamora",
+            "No One Knows",
+            "One Armed Scissor",
+            "Outer Space",
+            "Oye Mi Amor",
+            "Plush",
+            "The Power of Love",
+            "Radar Love",
+            "Rainbow in the Dark",
+            "Rehab",
+            "Saturday Night's Alright for Fighting",
+            "Smoke on the Water",
+            "Something Bigger, Something Brighter",
+            "Space Oddity",
+            "Stop Me If You Think You've Heard This One Before",
+            "This Bastard's Life",
+            "Viva la Resistance",
+            "Walk of Life",
+            "Werewolves of London",
+            "Whip It",
+            "Yoshimi Battles the Pink Robots Pt. 1"
+        ]
+
+    @functools.cached_property
+    def tracks_nds(self) -> List[str]:
+        return [
+            "Been Caught Stealing",
+            "Bohemian Rhapsody",
+            "Break on Through (To the Other Side)",
+            "China Grove",
+            "Cold as Ice",
+            "Combat Baby",
+            "Crazy Train",
+            "Crosstown Traffic",
+            "Get Free",
+            "The Hardest Button to Button",
+            "Here I Go Again",
+            "Humanoid",
+            "I Love Rock N' Roll",
+            "Just Like Heaven",
+            "Lasso",
+            "The Look",
+            "Midlife Crisis",
+            "Misery Business",
+            "Need You Tonight",
+            "Oh My God",
+            "Portions for Foxes",
+            "Rock Lobster",
+            "Roundabout",
+            "Sister Christian",
+            "Walkin' on the Sun"
+        ]
+
+
+# Archipelago Options
+class RockBand3NDSOnly(Toggle):
+    """
+    Indicates whether to only include the Nintendo DS tracks in the list for Rock Band 3.
+    """
+
+    display_name = "Rock Band 3 NDS Only"

--- a/worlds/keymasters_keep/games/rock_band_4_game.py
+++ b/worlds/keymasters_keep/games/rock_band_4_game.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class RockBand4ArchipelagoOptions:
+    pass
+
+
+class RockBand4Game(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Rock Band 4"
+    platform = KeymastersKeepGamePlatforms.XONE
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS4
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = RockBand4ArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "Ain't Messin 'Round",
+            "Albert",
+            "All Over You",
+            "Arabella",
+            "At Night in Dreams",
+            "Birth in Reverse",
+            "Brown Eyed Girl",
+            "Caught Up in You",
+            "Cedarwood Road",
+            "Centuries",
+            "Cold Clear Light",
+            "Dead Black (Heart of Ice)",
+            "Dream Genie",
+            "The Feast and the Famine",
+            "Fever",
+            "Follow You Down",
+            "Free Falling",
+            "Friday I'm In Love",
+            "Hail to the King",
+            "Halls of Valhalla",
+            "I Am Electric",
+            "I Bet My Life",
+            "I Miss the Misery",
+            "I Will Follow",
+            "The Impression That I Get",
+            "Kick It Out",
+            "Knock Em Down",
+            "Lazaretto",
+            "Light the Fuse",
+            "Light Up the Night",
+            "Little Miss Can't Be Wrong",
+            "Little White Church",
+            "Mainstream Kid",
+            "Metropolis—Part I: \"The Miracle and the Sleeper\"",
+            "Milwaukee",
+            "Miracle Man",
+            "My God Is the Sun",
+            "No One Like You",
+            "The One I Love",
+            "Panama",
+            "A Passage to Bangkok",
+            "Pistol Whipped",
+            "Prayer",
+            "Recession",
+            "Rock and Roll, Hoochie Koo",
+            "The Seeker",
+            "Short Skirt/Long Jacket",
+            "Somebody Told Me",
+            "Spiders",
+            "Start a Band",
+            "Still Into You",
+            "Superunknown",
+            "Suspicious Minds",
+            "That Smell",
+            "Tongue Tied",
+            "Toys in the Attic",
+            "Turn it Around",
+            "Uptown Funk",
+            "V-Bomb",
+            "Violent Shiver",
+            "The Warrior",
+            "What's Up?",
+            "The Wolf",
+            "You Make Loving Fun",
+            "Your Love"
+        ]
+
+
+# Archipelago Options
+# ...

--- a/worlds/keymasters_keep/games/rock_band_game.py
+++ b/worlds/keymasters_keep/games/rock_band_game.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import functools
+from typing import List
+
+from dataclasses import dataclass
+
+from ..game import Game
+from ..game_objective_template import GameObjectiveTemplate
+
+from ..enums import KeymastersKeepGamePlatforms
+
+
+@dataclass
+class RockBandArchipelagoOptions:
+    pass
+
+
+class RockBandGame(Game):
+    # Initial implementation by JCBoorgo
+
+    name = "Rock Band"
+    platform = KeymastersKeepGamePlatforms.X360
+
+    platforms_other = [
+        KeymastersKeepGamePlatforms.PS3,
+        KeymastersKeepGamePlatforms.PS2,
+        KeymastersKeepGamePlatforms.WII,
+    ]
+
+    is_adult_only_or_unrated = False
+
+    options_cls = RockBandArchipelagoOptions
+
+    def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
+        return list()
+    
+    def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        return [
+            GameObjectiveTemplate(
+                label="Play TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=False,
+                weight=3
+            ),
+            GameObjectiveTemplate(
+                label="Get a Full Combo on TRACK",
+                data={"TRACK": (self.tracks, 1)},
+                is_time_consuming=False,
+                is_difficult=True,
+                weight=1
+            ),
+        ]
+    
+    def tracks(self) -> List[str]:
+        return sorted(self.tracks_base)
+
+    @functools.cached_property
+    def tracks_base(self) -> List[str]:
+        return [
+            "Are You Gonna Be My Girl",
+            "Ballroom Blitz",
+            "Black Hole Sun",
+            "Blitzkrieg Bop",
+            "Celebrity Skin",
+            "Cherub Rock",
+            "Creep",
+            "Dani California",
+            "Dead on Arrival",
+            "Detroit Rock City",
+            "(Don't Fear) The Reaper",
+            "Electric Version",
+            "Enter Sandman",
+            "Epic",
+            "Flirtin' with Disaster",
+            "Foreplay/Long Time",
+            "Gimme Shelter",
+            "Go with the Flow",
+            "Green Grass and High Tides",
+            "Here It Goes Again",
+            "Highway Star",
+            "I Think I'm Paranoid",
+            "In Bloom",
+            "Learn to Fly",
+            "Main Offender",
+            "Maps",
+            "Mississippi Queen",
+            "Next to You",
+            "Orange Crush",
+            "Paranoid",
+            "Reptilia",
+            "Run to the Hills",
+            "Sabotage",
+            "Say It Ain't So",
+            "Should I Stay or Should I Go",
+            "Suffragette City",
+            "The Hand That Feeds",
+            "Tom Sawyer",
+            "Train Kept A-Rollin'",
+            "Vasoline",
+            "Wanted Dead or Alive",
+            "Wave of Mutilation",
+            "Welcome Home",
+            "When You Were Young",
+            "Won't Get Fooled Again"
+        ]
+
+
+# Archipelago Options
+# ...


### PR DESCRIPTION
Adds Rock Band 1 through 4 and Lego Rock Band. Two games (3 and Lego) have NDS-only switches because those releases are funny, otherwise they're all very direct implementations of the same concept from the Guitar Hero series.