### PR TITLE
Fix logic bug for RotMG

### DIFF
--- a/worlds/keymasters_keep/games/realm_of_the_mad_god_game.py
+++ b/worlds/keymasters_keep/games/realm_of_the_mad_god_game.py
@@ -222,11 +222,6 @@ class RealmOfTheMadGodGame(Game):
     def dungeons_base(self) -> List[str]:
         return [
             "The Realm",
-            "a Pirate Cave",
-            "a Forest Maze",
-            "a Spider Den",
-            "a Forbidden Jungle",
-            "The Hive",
             "a Snake Pit",
             "a Sprite World",
             "The Cave of a Thousand Treasures",
@@ -263,10 +258,25 @@ class RealmOfTheMadGodGame(Game):
         ]
 
     @functools.cached_property
+    def dungeons_potless(self) -> List[str]:
+        return [
+            "a Pirate Cave",
+            "a Forest Maze",
+            "a Spider Den",
+            "a Forbidden Jungle",
+            "The Hive",            
+        ]
+    
+    @functools.cached_property
     def dungeons_rare(self) -> List[str]:
         return [
-            "a Candyland Hunting Grounds ",
+            "a Candyland Hunting Grounds",
             "The Machine",
+        ]
+
+    @functools.cached_property
+    def dungeons_rare_potless(self) -> List[str]:
+        return [
             "The Beachzone",
         ]
 
@@ -302,7 +312,7 @@ class RealmOfTheMadGodGame(Game):
             "Forax",
         ]
 
-    def dungeons(self) -> List[str]:
+    def dungeons_with_pots(self) -> List[str]:
         dungeons = self.dungeons_base[:]
 
         if bool(self.archipelago_options.include_time_consuming_objectives.value):
@@ -313,6 +323,15 @@ class RealmOfTheMadGodGame(Game):
             dungeons.extend(self.dungeons_endgame)
         if self.has_dungeons_aliens:
             dungeons.extend(self.dungeons_aliens)
+
+        return sorted(dungeons)
+
+    def dungeons(self) -> List[str]:
+        dungeons = self.dungeons()[:]
+        dungeons.extend(self.dungeons_potless)
+        if bool(self.archipelago_options.include_time_consuming_objectives.value):
+            dungeons.extend(self.dungeons_rare_potless)
+
 
         return sorted(dungeons)
 
@@ -333,7 +352,7 @@ class RealmOfTheMadGodGame(Game):
         ]
 
     def potion_drops(self) -> List[str]:
-        potion_drops: List[str] = self.dungeons()[:]
+        potion_drops: List[str] = self.dungeons_with_pots()[:]
 
         potion_drops.extend(self.advanced_biomes())
         potion_drops.extend(self.advanced_biomes())


### PR DESCRIPTION
A small handful of dungeons cannot ever reasonably drop stat-increasing potions, and thus are not valid options for the potion drop objective. This was an oversight that I missed in the game proposal.

I fixed this by removing those dungeons from the main cached properties and putting them in dedicated ones. "dungeons_with_pots" runs as the old dungeons method did, with a new command taking the name "dungeons" which runs dungeons_with_pots and extends the list with the few potless dungeons. The objectives that don't care about pots one way or another should hook into this.

Also fixed: a stray space in a string "Candyland Hunting Grounds" has been deleted.