### PR TITLE
KMK: Fixed Enigmatic Portal Typo

### DIFF
--- a/worlds/keymasters_keep/enums.py
+++ b/worlds/keymasters_keep/enums.py
@@ -340,7 +340,7 @@ class KeymastersKeepLocations(enum.Enum):
     THE_ENCHANTED_GATEWAY_UNLOCK = "Unlock: The Enchanted Gateway"
     THE_ENCHANTED_PASSAGE_TRIAL = "Along the Enchanted Passage: TRIAL_NAME"
     THE_ENCHANTED_PASSAGE_UNLOCK = "Unlock: The Enchanted Passage"
-    THE_ENIGMATIC_PORTAL_TRIAL = "Beyond the Enigmatic Portal : TRIAL_NAME"
+    THE_ENIGMATIC_PORTAL_TRIAL = "Beyond the Enigmatic Portal: TRIAL_NAME"
     THE_ENIGMATIC_PORTAL_UNLOCK = "Unlock: The Enigmatic Portal"
     THE_ENIGMATIC_THRESHOLD_TRIAL = "Beyond the Enigmatic Threshold: TRIAL_NAME"
     THE_ENIGMATIC_THRESHOLD_UNLOCK = "Unlock: The Enigmatic Threshold"


### PR DESCRIPTION
## What is this fixing or adding?
The location names beginning with "Beyond the Enigmatic Portal" have an erroneous space between that name and the colon indicating the trial they're for. This removes that space.

## How was this tested?
I ran a test gen and observed that the typo had been removed.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/user-attachments/assets/919e4cba-7f5f-4070-8536-f2ad856ea1af)
After:
![image](https://github.com/user-attachments/assets/2885c524-01ff-4c1d-829b-31aed83adbe1)
