### PR TITLE
KMK: Sporecast Missions update

### DIFF
--- a/worlds/keymasters_keep/games/spore_game.py
+++ b/worlds/keymasters_keep/games/spore_game.py
@@ -390,6 +390,17 @@ class SporeSporecastExclusiveMissions(OptionSet):
         "The Metamorphosis",
         "The Space Race!",
         "Welcome to Dancetopia",
+        "Bloody Sundae",
+        "Incontinent Continent",
+        "Litterbox Gulch",
+        "My Big Fat Pig Wedding",
+        "Planet of Needin'",
+        "Readerdome",
+        "Shake It Up",
+        "Shenanigans' Fun-Tasy Theme Park",
+        "That's My Lunch!",
+        "The Chicken and the Road",
+        "Whiney and his Poo",
     ]
 
     default = valid_keys

--- a/worlds/keymasters_keep/games/spore_game.py
+++ b/worlds/keymasters_keep/games/spore_game.py
@@ -386,7 +386,7 @@ class SporeSporecastExclusiveMissions(OptionSet):
         "Robots vs Dragons",
         "Spoffit Calculator!",
         "SporeBall",
-        "The Meaningless",
+        "The Meaningless Turtle",
         "The Metamorphosis",
         "The Space Race!",
         "Welcome to Dancetopia",


### PR DESCRIPTION
## What is this fixing or adding?
Adds new names & one mission rename under the Sporecast missions category

## How was this tested?
Noticed when opening up Spore & checked wikipedia that the adventures were official created by Maxis and not by a third party. Kinda, by Robot Chicken writers. But the adventure itself was made by "Maxis" classifying it as a Maxis official adventure that can be found via sporecast.

As well as renamed one adventure to accurately match the ingame adventure name.

I also want the Space exclusive missions to no longer be "Time Consuming" the reason is with the mission that you have, the game assumes you have the mission available. Not sure how to remove that in the code without breaking it. So I figured if you would be able to do that for me on top of approving this PR, I would appreciate it.

## If this makes graphical changes, please attach screenshots.
