### PR TITLE
Skip Backlog or Custom Game meta games if they've been configured to be empty.

### DIFF
--- a/worlds/keymasters_keep/game.py
+++ b/worlds/keymasters_keep/game.py
@@ -73,6 +73,10 @@ class Game(metaclass=AutoGameRegister):
 
         return True
 
+    @property
+    def has_objectives(self) -> bool:
+        return bool(self.game_objective_templates())
+
     @abc.abstractmethod
     def optional_game_constraint_templates(self) -> List[GameObjectiveTemplate]:
         return list()

--- a/worlds/keymasters_keep/game_objective_generator.py
+++ b/worlds/keymasters_keep/game_objective_generator.py
@@ -191,6 +191,9 @@ class GameObjectiveGenerator:
 
             game_instance: Game = game(archipelago_options=self.archipelago_options)
 
+            if not game_instance.has_objectives:
+                continue
+
             if not include_adult_only_or_unrated_games and game.is_adult_only_or_unrated:
                 continue
 

--- a/worlds/keymasters_keep/games/custom_game.py
+++ b/worlds/keymasters_keep/games/custom_game.py
@@ -31,6 +31,9 @@ class CustomGame(Game):
         return list()
 
     def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        if not self.objectives():
+            return []
+
         return [
             GameObjectiveTemplate(
                 label="OBJECTIVE",

--- a/worlds/keymasters_keep/games/game_backlog_game.py
+++ b/worlds/keymasters_keep/games/game_backlog_game.py
@@ -32,6 +32,8 @@ class GameBacklogGame(Game):
         return list()
 
     def game_objective_templates(self) -> List[GameObjectiveTemplate]:
+        if not self.games() or not self.actions():
+            return []
         return [
             GameObjectiveTemplate(
                 label="ACTION GAME",

--- a/worlds/keymasters_keep/test/__init__.py
+++ b/worlds/keymasters_keep/test/__init__.py
@@ -1,0 +1,5 @@
+from test.bases import WorldTestBase
+
+
+class KeymastersKeepTestBase(WorldTestBase):
+    game = "Keymaster's Keep"

--- a/worlds/keymasters_keep/test/test_default_games.py
+++ b/worlds/keymasters_keep/test/test_default_games.py
@@ -1,0 +1,15 @@
+from worlds.keymasters_keep.test import KeymastersKeepTestBase
+
+
+class TestEmptyBacklog(KeymastersKeepTestBase):
+    options = {
+        "game_selection": ['Custom (META)', 'Game Backlog (META)'],
+        "game_backlog_game_selection": [],
+    }
+
+
+class TestEmptyCustom(KeymastersKeepTestBase):
+    options = {
+        "game_selection": ['Custom (META)', 'Game Backlog (META)'],
+        "custom_game_objectives": [],
+    }


### PR DESCRIPTION
Another simple-ish PR.

This makes Backlog and Custom Games return no objectives if they'd fail to evaluate.

I then added an additional filter to the game filter to ignore any games with no objectives.

There are also some tests thrown in for good measure (Mostly because it was the easiest way to check my code was working)